### PR TITLE
Fixes install for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 ## Simulater for testing spawn algorithms of monsters
+
+### Install:
+`pip install -r requirements.txt`
+
 ### How to use:
 start faster.bat and pythonServer.bat
 
-load a map bevore walking
+load a map before walking - http://127.0.0.1:8000/
 ### commands:
 - "updateMap" downloads mapData from mapzen and loads it
 - "route x" walk route x (names in routes.json)
@@ -21,3 +25,4 @@ load a map bevore walking
 
 
 encounters.json from https://github.com/pkmn-world/test-spawner
+pokemon.json from https://gist.github.com/shri/9754992

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-Shapely==1.6.16
+Shapely>=1.5.16
+matplotlib>=1.5.1


### PR DESCRIPTION
Ran into an issue regarding Shapely 1.6.16 not being available via pip on windows.
From http://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely it appears 1.5.16 is the most recent available to this platform.
